### PR TITLE
bump spock-core version to 1.1-groovy-2.3-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
     compile "org.codehaus.groovy:groovy-all:$groovyVersion"
 
-    testCompile 'org.spockframework:spock-core:1.0-groovy-2.3-SNAPSHOT'
+    testCompile 'org.spockframework:spock-core:1.1-groovy-2.3-SNAPSHOT'
 
     testRuntime 'cglib:cglib-nodep:3.1'
     testRuntime 'org.objenesis:objenesis:2.1'


### PR DESCRIPTION
Spock本家のバージョンアップに伴い、旧バージョンが[Sonatype OSS](https://oss.sonatype.org/content/repositories/snapshots/org/spockframework/)から削除され、利用できなくなっていたため修正しました。

[Sonatype OSS](https://oss.sonatype.org/content/repositories/snapshots/org/spockframework/)から引き続き引っ張ってくるかどうかは、別途相談したいので、issue立てます。