### PR TITLE
Rename gvm to sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ TDDBC for Groovy with Spock
 # Mac
 $ brew install gradle
 または、
-$ gvm install gradle
+$ sdk install gradle
 
 # Unix
-$ gvm install gradle
+$ sdk install gradle
 ```
-gvmについては、以下のURLを参考にしてインストールしてください
+sdkについては、以下のURLを参考にしてインストールしてください
 
-http://gvmtool.net/
+http://sdkman.io/
 
 #### Windows
 以下のURLを参考にしてインストールしてください。


### PR DESCRIPTION
@irof さんが java_junitで対応してくれていた[gvm to sdkの件](https://github.com/tddbc/java_junit/pull/17)、
groovy_spock側も同様だったので対応しました。